### PR TITLE
Support non-global git installs

### DIFF
--- a/bs.cmd
+++ b/bs.cmd
@@ -1,3 +1,0 @@
-@echo off 
-SET SCRIPT_DIR=%~dp0
-"C:\Program Files\Git\bin\sh.exe" --login -i -- "%SCRIPT_DIR%bs.sh" %*

--- a/install.ps1
+++ b/install.ps1
@@ -1,15 +1,38 @@
-$target_dir = $env:BS_DIR
-if (! $env:BS_DIR) {
-    $target_dir = "C:\Program Files\Git\cmd"
+if (Get-Command git -ErrorAction SilentlyContinue) {
+    $git_path = (Get-Command git) | Split-Path | Split-Path
 }
+
+$possible_paths = @($env:BS_DIR, "$($git_path)\cmd")
+$non_empty_paths = $possible_paths | where {$_}
+$target_dir = $non_empty_paths |    
+    where {(Test-Path $_)} |
+    select -First 1
+
+if (!($target_dir)) {
+    $checkedPaths = $non_empty_paths | foreach {$paths} {$paths += "'$_'`r`n"} {$paths}
+
+    Write-Error @"
+Couldn't find BS install path.  Checked: 
+$checkedPaths
+You can manually set the target install dir by setting an environment variable: `$env:BS_DIR
+"@
+    return
+}
+
 $source = "https://raw.githubusercontent.com/labaneilers/bs/master"
+iwr -uri "$source/bs" -outfile "$target_dir\bs.sh"
 
-if (!( test-path $target_dir)) {
-    "ERROR: Couldn't find default install dir: $target_dir"
-    "You can set the target install dir by setting an environment variable: `$env:BS_DIR"
-} else {
-    iwr -uri "$source/bs.cmd" -outfile "$target_dir\bs.cmd"
-    iwr -uri "$source/bs" -outfile "$target_dir\bs.sh"
-
-    "Installed bs at $target_dir\bs.cmd"
+# Write customized cmd file pointing to git's bash executable
+$bash_path = "$git_path\bin\sh.exe"
+if (!(Test-Path $bash_path)) {
+    Write-Error "Could not find bash executable (tried '$bash_path')"
 }
+
+$cmd_path = "$target_dir\bs.cmd"
+rm -Force $cmd_path
+
+Set-Content -Path $cmd_path -Value "@echo off"
+Set-Content -Path $cmd_path -Value "SET SCRIPT_DIR=%~dp0"
+Set-Content -Path $cmd_path -Value "`"$bash_path`" --login -i -- `"%SCRIPT_DIR%bs.sh`" %*"
+
+"Installed bs at $target_dir\bs.cmd"


### PR DESCRIPTION
Previous powershell installer script and `bs.cmd` files assumed a global git install (in `C:\Program Files`).  However, if git is installed for the current user only then git will be in `%USERPROFILE%\AppData\Local\Programs\Git`.  

This change allows for any git install directory as long as it's in the current `$Path`.  It also auto-generates the `bs.cmd` file based on git's bash executable location.