### PR TITLE
Changes required for MacOS Support

### DIFF
--- a/bs
+++ b/bs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/bs
+++ b/bs
@@ -59,7 +59,7 @@ ERROR_BANNER="bs ERROR:"
 SCRIPT_PATH="./bs/$1.sh"
 
 function list() {
-    find ./bs -maxdepth 1 -name "*.sh" -type f -printf "%f\n" | sed s/.sh$//i | grep -v "^_" | grep -v "^default$"
+    find ./bs -maxdepth 1 -name "*.sh" -type f -print | sed s/.sh$//i | grep -v "^_" | grep -v "^default$"
 }
 
 function print-help() {


### PR DESCRIPTION
* Updated shebang to use `/usr/bin/env bash` since MacOS installs v3.2 at /bin/bash
* MacOS' version of find does not support the printf argument